### PR TITLE
ABF-2700: Use plain javascript to compute monthsDelta, allowing us to remove the heavy moment lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ import { PENSION } from '@equisoft/tax-ca';
 const { OAS, CPP } = PENSION;
 
 console.log("OAS maximum age: ", OAS.MAX_AGE); // 70
-console.log("CPP AAF for age 67: ", CPP.getAAF(67)); // 1.168
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "webpack": "~4.41.2",
     "webpack-cli": "~3.3.9"
   },
-  "dependencies": {
-    "moment": "^2.24.0",
-    "moment-range": "^4.0.2"
-  }
+  "dependencies": {}
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,6 @@
-import * as Moment from 'moment';
-import { extendMoment } from 'moment-range';
-const moment = extendMoment(Moment);
-
 export function monthsDelta(firstDate: Date, secondDate: Date): number {
-    return moment.range(firstDate, secondDate).diff('months');
+    const monthsDiff = secondDate.getMonth() - firstDate.getMonth();
+    const yearsDiff = secondDate.getFullYear() - firstDate.getFullYear();
+
+    return monthsDiff + (12 * yearsDiff) - (secondDate.getDate() < firstDate.getDate() ? 1 : 0);
 }

--- a/src/utils/tests/date.spec.ts
+++ b/src/utils/tests/date.spec.ts
@@ -1,18 +1,24 @@
 import { monthsDelta } from '../date';
 
-describe('monthsDelta', () => {
-    it.each`
-        firstDate                                   | secondDate                                    | expected
-        ${new Date(2020, 0, 1)}  | ${new Date(2020, 0, 1)}    | ${0}
-        ${new Date(2020, 3, 1)}  | ${new Date(2020, 0, 1)}    | ${-3}
-        ${new Date(2020, 0, 1)}  | ${new Date(2020, 3, 1)}    | ${3}
-        ${new Date(2020, 0, 15)}  | ${new Date(2020, 3, 17)}  | ${3}
-        ${new Date(2020, 0, 15)}  | ${new Date(2020, 4, 1)}   | ${3}
-        ${new Date(2020, 0, 15)}  | ${new Date(2020, 3, 13)}  | ${2}
-        ${new Date(2020, 0, 30)}  | ${new Date(2020, 1, 1)}  | ${0}
-    `('should round $value with a precision of $precision digits', ({ firstDate, secondDate, expected }) => {
-        const delta = monthsDelta(firstDate, secondDate);
+type TestCase = [Date, Date, number];
 
-        expect(delta).toBe(expected);
+describe('monthsDelta', () => {
+    const testCases: TestCase[] = [
+        [new Date(2020, 0, 1), new Date(2020, 0, 1), 0],
+        [new Date(2020, 3, 1), new Date(2020, 0, 1), -3],
+        [new Date(2020, 0, 1), new Date(2020, 3, 1), 3],
+        [new Date(2020, 0, 15), new Date(2020, 3, 17), 3],
+        [new Date(2020, 0, 15), new Date(2020, 4, 1), 3],
+        [new Date(2020, 0, 15), new Date(2020, 3, 13), 2],
+        [new Date(2020, 0, 30), new Date(2020, 1, 1), 0],
+        [new Date(2020, 2, 31), new Date(2020, 3, 30), 0],
+        [new Date(2020, 2, 30), new Date(2021, 3, 30), 13],
+    ];
+
+    testCases.forEach(([from, to, expected]) => {
+        const testName = `should return ${expected} months between ${from.toDateString()} and ${to.toDateString()}`;
+        const testCase = () => expect(monthsDelta(from, to)).toBe(expected);
+
+        it(testName, testCase);
     });
 });

--- a/src/utils/tests/date.spec.ts
+++ b/src/utils/tests/date.spec.ts
@@ -1,24 +1,18 @@
 import { monthsDelta } from '../date';
 
-type TestCase = [Date, Date, number];
-
 describe('monthsDelta', () => {
-    const testCases: TestCase[] = [
-        [new Date(2020, 0, 1), new Date(2020, 0, 1), 0],
-        [new Date(2020, 3, 1), new Date(2020, 0, 1), -3],
-        [new Date(2020, 0, 1), new Date(2020, 3, 1), 3],
-        [new Date(2020, 0, 15), new Date(2020, 3, 17), 3],
-        [new Date(2020, 0, 15), new Date(2020, 4, 1), 3],
-        [new Date(2020, 0, 15), new Date(2020, 3, 13), 2],
-        [new Date(2020, 0, 30), new Date(2020, 1, 1), 0],
-        [new Date(2020, 2, 31), new Date(2020, 3, 30), 0],
-        [new Date(2020, 2, 30), new Date(2021, 3, 30), 13],
-    ];
-
-    testCases.forEach(([from, to, expected]) => {
-        const testName = `should return ${expected} months between ${from.toDateString()} and ${to.toDateString()}`;
-        const testCase = () => expect(monthsDelta(from, to)).toBe(expected);
-
-        it(testName, testCase);
+    it.each`
+        firstDate                                  | secondDate                                  | expected
+        ${new Date(2020, 0, 1)}  | ${new Date(2020, 0, 1)}   | ${0}
+        ${new Date(2020, 3, 1)}  | ${new Date(2020, 0, 1)}   | ${-3}
+        ${new Date(2020, 0, 1)}  | ${new Date(2020, 3, 1)}   | ${3}
+        ${new Date(2020, 0, 15)} | ${new Date(2020, 3, 17)}  | ${3}
+        ${new Date(2020, 0, 15)} | ${new Date(2020, 4, 1)}   | ${3}
+        ${new Date(2020, 0, 15)} | ${new Date(2020, 3, 13)}  | ${2}
+        ${new Date(2020, 0, 30)} | ${new Date(2020, 1, 1)}   | ${0}
+        ${new Date(2020, 2, 31)} | ${new Date(2020, 3, 30)}  | ${0}
+        ${new Date(2020, 2, 30)} | ${new Date(2021, 3, 30)}  | ${13}
+    `('should return $expected months between $firstDate and $secondDate', ({ firstDate, secondDate, expected }) => {
+        expect(monthsDelta(firstDate, secondDate)).toBe(expected);
     });
 });

--- a/src/utils/tests/math.spec.ts
+++ b/src/utils/tests/math.spec.ts
@@ -1,4 +1,4 @@
-import { roundToPrecision, clamp } from '../math';
+import { clamp, roundToPrecision } from '../math';
 
 describe('roundToPrecision', () => {
     it('should round to integer by default', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,14 +1612,6 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-symbol@^3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.2.tgz#859fdd34f32e905ff06d752e7171ddd4444a7ed1"
@@ -1752,13 +1744,6 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
-
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -3344,18 +3329,6 @@ mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment-range@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/moment-range/-/moment-range-4.0.2.tgz#f7c3863df2a1ed7fd1822ba5a7bcf53a78701be9"
-  integrity sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==
-  dependencies:
-    es6-symbol "^3.1.0"
-
-moment@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -4889,11 +4862,6 @@ type@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Tel que mentionné par Maxime M. il semble un peu overkill d'ajouter une aussi grosse librairie (moment) simplement pour une seule fonction (que la plupart des gens n'utiliseront pas). Certaine applications ont des considération envers le size de leur bundle, et donc il est judicieux de faire en sorte de garder notre lib lean. 
Cela explique donc le choix fait ici.

- [x] S'assurer que les résultats de _monthsDelta_ n'ont pas été altéré (les tests sont bon pour ça)
- [ ] Une nouvelle release _patch_ devra être faites lorsque nous aurons mergé cette PR.