### PR TITLE
ABF-3282: Fix TFSA ceiling projections

### DIFF
--- a/src/investments/tax-free-savings-account.ts
+++ b/src/investments/tax-free-savings-account.ts
@@ -9,10 +9,15 @@ Revised 2020-12-21
 
 export interface TaxFreeSavingsAccount {
     MAX_CONTRIBUTION: number;
+    UNROUNDED_MAX_CONTRIBUTION: number;
     ROUNDING_FACTOR: number;
+    UPDATE_YEAR: number;
 }
 
 export const TFSA: TaxFreeSavingsAccount = {
     MAX_CONTRIBUTION: 6000,
+    // Lastest unrounded contribution change that changed rounded factor bracket (5847.32 -> 6000)
+    UNROUNDED_MAX_CONTRIBUTION: 5850,
     ROUNDING_FACTOR: 500,
+    UPDATE_YEAR: 2019,
 };


### PR DESCRIPTION
Suite à un talk avec Kev, il était préférable d'utiliser la valeur qui n'est pas rounded pour appliquer l'inflation. Donc nous nous sommes fier au tableau dans la carte pour prendre la dernière valeur qui à changé (5500 -> 6000) et nous avons pris la valeur qui n'était pas rounded up (5847.32)