### PR TITLE
ABF-3472 : Mise à jour des normes d'hypothèses de projection IQPF avril 2021

### DIFF
--- a/src/misc/iqpf-stats.ts
+++ b/src/misc/iqpf-stats.ts
@@ -1,8 +1,8 @@
 /*
 Sources:
-	https://www.iqpf.org/docs/default-source/outils/iqpf-normes-projection2020.pdf
+	https://www.iqpf.org/docs/default-source/outils/iqpf-normes-projection2021.pdf
 
-Revised 2020-05-04
+Revised 2021-05-05
 */
 
 export interface ReturnRates {
@@ -23,12 +23,12 @@ export interface IQPFStatistics {
 export const IQPF: IQPFStatistics = {
     INFLATION: 0.020,
     RETURN_RATES: {
-        SHORT_TERM: 0.024,
-        FIXED_INCOME: 0.029,
-        CANADIAN_EQUITIES: 0.061,
-        CONSERVATIVE_PORTFOLIO: 0.024,
-        BALANCED_PORTFOLIO: 0.033,
-        DYNAMIC_PORTFOLIO: 0.043,
+        SHORT_TERM: 0.023,
+        FIXED_INCOME: 0.027,
+        CANADIAN_EQUITIES: 0.062,
+        CONSERVATIVE_PORTFOLIO: 0.023,
+        BALANCED_PORTFOLIO: 0.032,
+        DYNAMIC_PORTFOLIO: 0.044,
     },
-    BORROWING_RATE: 0.044,
+    BORROWING_RATE: 0.043,
 };

--- a/src/pension/old-age-security.ts
+++ b/src/pension/old-age-security.ts
@@ -3,8 +3,9 @@ Sources:
     https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.html
     https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.html
     https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/eligibility.html (delay bonus)
+    https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments.html
 
-Revised 2019-12-23
+Revised 2021-05-05
 */
 
 import { addYearsToDate, getMonthsDiff, now } from '../utils/date';
@@ -52,7 +53,7 @@ export const OAS: OldAgeSecurity = {
     },
     MAX_AGE: 70,
     MIN_AGE: 65,
-    MONTHLY_PAYMENT_MAX: 614.14,
+    MONTHLY_PAYMENT_MAX: 618.45,
     MONTHLY_DELAY_BONUS: 0.006,
     REPAYMENT: {
         MAX: 128149,


### PR DESCRIPTION
-  Le taux de rendement en prod au bas du module Placements devraient être de 3,30% avant la retraite et de 2,40% après la retraite.
- Suite à la modification proposée dans ce JIRA, le taux de rendement au bas du module devrait être de 3,20% et de 2,30%

- Bonus : La PSV devrait maintenant être 618 par mois et 7416 par année. 