### PR TITLE
ABF-4209: Rename age to beginningOfYearAge

### DIFF
--- a/src/investments/registered-retirement-income-fund.ts
+++ b/src/investments/registered-retirement-income-fund.ts
@@ -61,6 +61,6 @@ export const RRIF: RegisteredRetirementIncomeFund = {
     },
 };
 
-export function getMinimumWithdrawalPercentage(age: number): number {
-    return age >= 71 ? RRIF.MIN_WITHDRAWAL_PCT[age] : 1 / (90 - age);
+export function getMinimumWithdrawalPercentage(beginningOfYearAge: number): number {
+    return beginningOfYearAge >= 71 ? RRIF.MIN_WITHDRAWAL_PCT[beginningOfYearAge] : 1 / (90 - beginningOfYearAge);
 }


### PR DESCRIPTION
Le paramètre a simplement été renommé pour éviter les erreurs en l'utilisant.