### PR TITLE
ci(renovate): remove reviewers for renovate config, as it is handled by github codeowner feature

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
         "github>kronostechnologies/standards:renovate-base"
     ],
 
-    reviewers: ["team:team-abf"],
     rebaseWhen: "conflicted",
 
     js: {


### PR DESCRIPTION
ABF-5701

Le setting des reviewers est géré par le setting Code Owners dans Github.

### Qualité du Code
- [ ] Les nouvelles fonctionnalités sont testées unitairement.
