### PR TITLE
ABF-7425 feat(public-pension-plan): update pensionable earnings factor for supplemental contributions

### DIFF
--- a/src/pension/canada-pension-plan.ts
+++ b/src/pension/canada-pension-plan.ts
@@ -23,7 +23,7 @@ export const CPP: PublicPensionPlan = {
             SUP_MAX: 73200,
             SUP_FACTORS: [
                 { FROM: 2024, TO: 2024, FACTOR: 1 },
-                { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.14 },
+                { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.07 },
             ],
         },
         RATES: {

--- a/src/pension/canada-pension-plan.ts
+++ b/src/pension/canada-pension-plan.ts
@@ -5,7 +5,7 @@ Sources
     https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/cpp-price.html
 
 Revised
-    2023-01-02
+    2024-01-09
 */
 
 import { addYearsToDate, getMonthsDiff, now } from '../utils/date';
@@ -22,8 +22,7 @@ export const CPP: PublicPensionPlan = {
             // Year's additional maximum pensionable earnings (YAMPE), approx. 114% of AVG_MAX
             SUP_MAX: 73200,
             SUP_FACTORS: [
-                { FROM: 2019, TO: 2023, FACTOR: 1 },
-                { FROM: 2024, TO: 2024, FACTOR: 1.07 },
+                { FROM: 2024, TO: 2024, FACTOR: 1 },
                 { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.14 },
             ],
         },

--- a/src/pension/quebec-pension-plan.ts
+++ b/src/pension/quebec-pension-plan.ts
@@ -22,7 +22,7 @@ export const QPP: PublicPensionPlan = {
             SUP_MAX: 73200,
             SUP_FACTORS: [
                 { FROM: 2024, TO: 2024, FACTOR: 1 },
-                { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.14 },
+                { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.07 },
             ],
         },
         RATES: {

--- a/src/pension/quebec-pension-plan.ts
+++ b/src/pension/quebec-pension-plan.ts
@@ -4,7 +4,7 @@ Sources
     https://www.retraitequebec.gouv.qc.ca/fr/publications/nos-programmes/regime-de-rentes-du-quebec/retraite/Pages/revenus-de-travail-admissibles-et-cotisations.aspx
 
 Revised
-    2024-01-02
+    2024-01-09
 */
 
 import { addYearsToDate, getMonthsDiff, now } from '../utils/date';
@@ -21,8 +21,7 @@ export const QPP: PublicPensionPlan = {
             // Year's additional maximum pensionable earnings (YAMPE), approx. 114% of AVG_MAX
             SUP_MAX: 73200,
             SUP_FACTORS: [
-                { FROM: 2019, TO: 2023, FACTOR: 1 },
-                { FROM: 2024, TO: 2024, FACTOR: 1.07 },
+                { FROM: 2024, TO: 2024, FACTOR: 1 },
                 { FROM: 2025, TO: Number.MAX_SAFE_INTEGER, FACTOR: 1.14 },
             ],
         },


### PR DESCRIPTION
ABF-7425

Mise à jour du SUP_FACTORS pour le calcul du MGA lors des contributions supplémentaires.

### Specific tests
- [x] Pour le SUP_FACTORS, les années inutiles (plus petites que 2024 sont supprimés)
- [x] Le facteur pour 2024 est de 1 puisque la constante SUP_MAX est la valeur réelle pour 2024 sur laquelle il n'est plus utile d'appliquer un ratio.

### Code quality
- [x] New features are unit tested.
