### PR TITLE
ABF-9123 Add YAMPE_AVG_5 constant to tax-ca

### DIFF
--- a/src/pension/canada-pension-plan.ts
+++ b/src/pension/canada-pension-plan.ts
@@ -13,19 +13,21 @@ import { clamp, roundToPrecision } from '../utils/math';
 import { PublicPensionPlan } from './public-pension-plan';
 
 export const CPP: PublicPensionPlan = {
-    CONTRIBUTIONS: {
-        PENSIONABLE_EARNINGS: {
-            MAX: 71300,
-            MIN: 3500,
-            // Average YMPE of the last 5 year (including current year)
-            AVG_MAX: 66580,
-            // Year's additional maximum pensionable earnings (YAMPE)
-            SUP_MAX: 81200,
-        },
-        RATES: {
-            BASE: 0.0595,
-            ENHANCEMENT_STEP_2: 0.04,
-        },
+    PENSIONABLE_EARNINGS: {
+        BASIC_EXEMPTION: 3500,
+        // Year's maximum pensionable earnings (YMPE)
+        YMPE: 71300,
+        // Average YMPE of the last 5 year (including current year)
+        YMPE_AVG_5: 66580,
+        // Year's additional maximum pensionable earnings (YAMPE)
+        YAMPE: 81200,
+        // Year's additional maximum pensionable earnings (YAMPE) of the last 5 year (including current year)
+        // YAMPE * 0.942 (Temporary factor suggested by Martin Dupras, used to estimate until we have the right value)
+        YAMPE_AVG_5: 76490,
+    },
+    CONTRIBUTION_RATES: {
+        BASE: 0.0595,
+        ENHANCEMENT_STEP_2: 0.04,
     },
     DEATH_BENEFIT: { RATE: 0.5 },
     DEFAULT_REFERENCE_AGE: 65,

--- a/src/pension/canada-pension-plan.ts
+++ b/src/pension/canada-pension-plan.ts
@@ -43,42 +43,7 @@ export const CPP: PublicPensionPlan = {
         FROM_45_TO_64: 9250.56,
         OVER_64_WITHOUT_PENSION: 10317.60,
     },
-    getRequestDateFactor(birthDate: Date, requestDate: Date, customReferenceDate?: Date): number {
-        const { BONUS, PENALTY } = this.MONTHLY_DELAY;
 
-        const minRequestDate = addYearsToDate(birthDate, this.MIN_REQUEST_AGE);
-        const maxRequestDate = addYearsToDate(birthDate, this.MAX_REQUEST_AGE);
-        const referenceDate = customReferenceDate || addYearsToDate(birthDate, this.DEFAULT_REFERENCE_AGE);
-
-        const monthsToToday = getMonthsDiff(birthDate, now());
-        const monthsToMinRequestDate = getMonthsDiff(birthDate, minRequestDate);
-        const monthsToMaxRequestDate = getMonthsDiff(birthDate, maxRequestDate);
-        const monthsToReferenceDate = getMonthsDiff(birthDate, referenceDate);
-        const monthsToRequestDate = getMonthsDiff(birthDate, requestDate);
-        const monthsToLastBirthDay = monthsToToday - (monthsToToday % 12);
-
-        // Request date is before minimum request date
-        if (monthsToRequestDate < monthsToMinRequestDate) {
-            return 0;
-        }
-        // Analysis date is after the maximum request date
-        if (monthsToMaxRequestDate < monthsToToday) {
-            return 1;
-        }
-        // Analysis date is after reference date and request date is before last birthday
-        if (monthsToToday > monthsToReferenceDate && monthsToRequestDate < monthsToLastBirthDay) {
-            return 1;
-        }
-
-        let monthsDelta = clamp(monthsToRequestDate, monthsToMinRequestDate, monthsToMaxRequestDate);
-        monthsDelta -= Math.max(monthsToLastBirthDay, monthsToReferenceDate);
-
-        return 1 + (monthsDelta * (monthsDelta >= 0 ? BONUS : PENALTY));
-    },
-    getAverageIndexationRate(): number {
-        const sum = this.INDEXATION_RATE_REFERENCES.reduce((previous, current) => previous + current[1], 0);
-        return roundToPrecision(sum / this.INDEXATION_RATE_REFERENCES.length, 3);
-    },
     INDEXATION_RATE_REFERENCES: [ // Previous year inflation used as indexation
         [2007, 0.020],
         [2008, 0.022],
@@ -178,4 +143,40 @@ export const CPP: PublicPensionPlan = {
         UNDER_65: 0.375,
     },
     YEARS_TO_FULL_PENSION: 40,
+    getRequestDateFactor(birthDate: Date, requestDate: Date, customReferenceDate?: Date): number {
+        const { BONUS, PENALTY } = this.MONTHLY_DELAY;
+
+        const minRequestDate = addYearsToDate(birthDate, this.MIN_REQUEST_AGE);
+        const maxRequestDate = addYearsToDate(birthDate, this.MAX_REQUEST_AGE);
+        const referenceDate = customReferenceDate || addYearsToDate(birthDate, this.DEFAULT_REFERENCE_AGE);
+
+        const monthsToToday = getMonthsDiff(birthDate, now());
+        const monthsToMinRequestDate = getMonthsDiff(birthDate, minRequestDate);
+        const monthsToMaxRequestDate = getMonthsDiff(birthDate, maxRequestDate);
+        const monthsToReferenceDate = getMonthsDiff(birthDate, referenceDate);
+        const monthsToRequestDate = getMonthsDiff(birthDate, requestDate);
+        const monthsToLastBirthDay = monthsToToday - (monthsToToday % 12);
+
+        // Request date is before minimum request date
+        if (monthsToRequestDate < monthsToMinRequestDate) {
+            return 0;
+        }
+        // Analysis date is after the maximum request date
+        if (monthsToMaxRequestDate < monthsToToday) {
+            return 1;
+        }
+        // Analysis date is after reference date and request date is before last birthday
+        if (monthsToToday > monthsToReferenceDate && monthsToRequestDate < monthsToLastBirthDay) {
+            return 1;
+        }
+
+        let monthsDelta = clamp(monthsToRequestDate, monthsToMinRequestDate, monthsToMaxRequestDate);
+        monthsDelta -= Math.max(monthsToLastBirthDay, monthsToReferenceDate);
+
+        return 1 + (monthsDelta * (monthsDelta >= 0 ? BONUS : PENALTY));
+    },
+    getAverageIndexationRate(): number {
+        const sum = this.INDEXATION_RATE_REFERENCES.reduce((previous, current) => previous + current[1], 0);
+        return roundToPrecision(sum / this.INDEXATION_RATE_REFERENCES.length, 3);
+    },
 };

--- a/src/pension/public-pension-plan.ts
+++ b/src/pension/public-pension-plan.ts
@@ -5,20 +5,16 @@ export interface Factor {
 }
 
 export interface PensionableEarnings {
-    MAX: number;
-    MIN: number;
-    AVG_MAX: number;
-    SUP_MAX: number;
+    BASIC_EXEMPTION: number;
+    YMPE: number;
+    YMPE_AVG_5: number;
+    YAMPE: number;
+    YAMPE_AVG_5: number;
 }
 
-export interface Rates {
+export interface ContributionRates {
     BASE: number;
     ENHANCEMENT_STEP_2: number;
-}
-
-export interface Contributions {
-    PENSIONABLE_EARNINGS: PensionableEarnings;
-    RATES: Rates;
 }
 
 export interface DeathBenefit {
@@ -73,7 +69,8 @@ export interface SurvivorRate {
 }
 
 export interface PublicPensionPlan {
-    CONTRIBUTIONS: Contributions;
+    PENSIONABLE_EARNINGS: PensionableEarnings,
+    CONTRIBUTION_RATES: ContributionRates,
     DEATH_BENEFIT: DeathBenefit;
     DEFAULT_REFERENCE_AGE: number;
     FLAT_BENEFIT: FlatBenefit;

--- a/src/pension/quebec-pension-plan.ts
+++ b/src/pension/quebec-pension-plan.ts
@@ -41,42 +41,6 @@ export const QPP: PublicPensionPlan = {
         FROM_45_TO_64: 13615.32,
         OVER_64_WITHOUT_PENSION: 10130.88,
     },
-    getRequestDateFactor(birthDate: Date, requestDate: Date, customReferenceDate?: Date): number {
-        const { BONUS, PENALTY } = this.MONTHLY_DELAY;
-
-        const minRequestDate = addYearsToDate(birthDate, this.MIN_REQUEST_AGE);
-        const maxRequestDate = addYearsToDate(birthDate, this.MAX_REQUEST_AGE);
-        const referenceDate = customReferenceDate || addYearsToDate(birthDate, this.DEFAULT_REFERENCE_AGE);
-
-        const monthsToToday = getMonthsDiff(birthDate, now());
-        const monthsToMinRequestDate = getMonthsDiff(birthDate, minRequestDate);
-        const monthsToMaxRequestDate = getMonthsDiff(birthDate, maxRequestDate);
-        const monthsToReferenceDate = getMonthsDiff(birthDate, referenceDate);
-        const monthsToRequestDate = getMonthsDiff(birthDate, requestDate);
-        const monthsToLastBirthDay = monthsToToday - (monthsToToday % 12);
-
-        // Request date is before minimum request date
-        if (monthsToRequestDate < monthsToMinRequestDate) {
-            return 0;
-        }
-        // Analysis date is after the maximum request date
-        if (monthsToMaxRequestDate < monthsToToday) {
-            return 1;
-        }
-        // Analysis date is after reference date and request date is before last birthday
-        if (monthsToToday > monthsToReferenceDate && monthsToRequestDate < monthsToLastBirthDay) {
-            return 1;
-        }
-
-        let monthsDelta = clamp(monthsToRequestDate, monthsToMinRequestDate, monthsToMaxRequestDate);
-        monthsDelta -= Math.max(monthsToLastBirthDay, monthsToReferenceDate);
-
-        return 1 + (monthsDelta * (monthsDelta >= 0 ? BONUS : PENALTY));
-    },
-    getAverageIndexationRate(): number {
-        const sum = this.INDEXATION_RATE_REFERENCES.reduce((previous, current) => previous + current[1], 0);
-        return roundToPrecision(sum / this.INDEXATION_RATE_REFERENCES.length, 2);
-    },
     INDEXATION_RATE_REFERENCES: [
         [2007, 0.021],
         [2008, 0.020],
@@ -178,4 +142,40 @@ export const QPP: PublicPensionPlan = {
         UNDER_65: 0.375,
     },
     YEARS_TO_FULL_PENSION: 40,
+    getRequestDateFactor(birthDate: Date, requestDate: Date, customReferenceDate?: Date): number {
+        const { BONUS, PENALTY } = this.MONTHLY_DELAY;
+
+        const minRequestDate = addYearsToDate(birthDate, this.MIN_REQUEST_AGE);
+        const maxRequestDate = addYearsToDate(birthDate, this.MAX_REQUEST_AGE);
+        const referenceDate = customReferenceDate || addYearsToDate(birthDate, this.DEFAULT_REFERENCE_AGE);
+
+        const monthsToToday = getMonthsDiff(birthDate, now());
+        const monthsToMinRequestDate = getMonthsDiff(birthDate, minRequestDate);
+        const monthsToMaxRequestDate = getMonthsDiff(birthDate, maxRequestDate);
+        const monthsToReferenceDate = getMonthsDiff(birthDate, referenceDate);
+        const monthsToRequestDate = getMonthsDiff(birthDate, requestDate);
+        const monthsToLastBirthDay = monthsToToday - (monthsToToday % 12);
+
+        // Request date is before minimum request date
+        if (monthsToRequestDate < monthsToMinRequestDate) {
+            return 0;
+        }
+        // Analysis date is after the maximum request date
+        if (monthsToMaxRequestDate < monthsToToday) {
+            return 1;
+        }
+        // Analysis date is after reference date and request date is before last birthday
+        if (monthsToToday > monthsToReferenceDate && monthsToRequestDate < monthsToLastBirthDay) {
+            return 1;
+        }
+
+        let monthsDelta = clamp(monthsToRequestDate, monthsToMinRequestDate, monthsToMaxRequestDate);
+        monthsDelta -= Math.max(monthsToLastBirthDay, monthsToReferenceDate);
+
+        return 1 + (monthsDelta * (monthsDelta >= 0 ? BONUS : PENALTY));
+    },
+    getAverageIndexationRate(): number {
+        const sum = this.INDEXATION_RATE_REFERENCES.reduce((previous, current) => previous + current[1], 0);
+        return roundToPrecision(sum / this.INDEXATION_RATE_REFERENCES.length, 2);
+    },
 };

--- a/src/pension/quebec-pension-plan.ts
+++ b/src/pension/quebec-pension-plan.ts
@@ -11,19 +11,21 @@ import { clamp, roundToPrecision } from '../utils/math';
 import { PublicPensionPlan } from './public-pension-plan';
 
 export const QPP: PublicPensionPlan = {
-    CONTRIBUTIONS: {
-        PENSIONABLE_EARNINGS: {
-            MAX: 71300,
-            MIN: 3500,
-            // Average YMPE of the last 5 year (including current year)
-            AVG_MAX: 66580,
-            // Year's additional maximum pensionable earnings (YAMPE)
-            SUP_MAX: 81200,
-        },
-        RATES: {
-            BASE: 0.064,
-            ENHANCEMENT_STEP_2: 0.04,
-        },
+    PENSIONABLE_EARNINGS: {
+        BASIC_EXEMPTION: 3500,
+        // Year's maximum pensionable earnings (YMPE)
+        YMPE: 71300,
+        // Average YMPE of the last 5 year (including current year)
+        YMPE_AVG_5: 66580,
+        // Year's additional maximum pensionable earnings (YAMPE)
+        YAMPE: 81200,
+        // Year's additional maximum pensionable earnings (YAMPE) of the last 5 year (including current year)
+        // YAMPE * 0.942 (Temporary factor suggested by Martin Dupras, used to estimate until we have the right value)
+        YAMPE_AVG_5: 76490,
+    },
+    CONTRIBUTION_RATES: {
+        BASE: 0.064,
+        ENHANCEMENT_STEP_2: 0.04,
     },
     DEATH_BENEFIT: { RATE: 0.5 },
     DEFAULT_REFERENCE_AGE: 65,


### PR DESCRIPTION
ABF-9123

What changed.
1. Sortir PENSIONABLE_EARNINGS de CONTRIBUTIONS, car les constantes sont également utilisées pour calculer les revenus et pas seulement les contributions.
2. Renommer les MAX, MIN, et AVG pour que ça ce soit exactement le jargon du domaine.
3. Ajouter la constante YAMPE_AVG_5
4. Déplacer les fonctions au bas du fichier et les constantes au début.

### Code quality
- [ ] New features are unit tested.
