### PR TITLE
[ABF-9131] fix(QPP): updated COMBINED_RETIREMENT_SURVIVOR value

### DIFF
--- a/src/pension/quebec-pension-plan.ts
+++ b/src/pension/quebec-pension-plan.ts
@@ -126,8 +126,8 @@ export const QPP: PublicPensionPlan = {
     MAX_PENSION: {
         // Max amount at age 65
         RETIREMENT: 17196,
-        // Max retirement amount at age 65 + Add. amount for disability
-        COMBINED_RETIREMENT_SURVIVOR: 24377.52,
+        // Value must be the same as Max Retirement for the QPP
+        COMBINED_RETIREMENT_SURVIVOR: 17196,
         DEATH_BENEFIT: 2500,
     },
     MAX_REQUEST_AGE: 72,


### PR DESCRIPTION
### Specific tests
- [ ] Uniquement pour le QPP, le montant pour le COMBINED_RETIREMENT_SURVIVOR devrait être de 17196.
- [ ] Modifier le commentaire pour spécifier ceci : Value must be the same as Max Retirement for the QPP