### PR TITLE
[ABF-9937] dev(taxCredit): Ajout paramètre taxCredit au taxCalculation(provincial, federal)

### DIFF
--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -516,10 +516,11 @@ export function getFederalTaxAmount(
     grossIncome: number,
     inflationRate = 0,
     yearsToInflate = 0,
+    taxCredit = 0,
 ): number {
     const federalBaseTaxAmount = getFederalBaseTaxAmount(grossIncome, inflationRate, yearsToInflate);
     const baseCredit = getFederalBaseCredit(inflationRate, yearsToInflate);
-    const federalTax = Math.max(federalBaseTaxAmount - baseCredit, 0);
+    const federalTax = Math.max(federalBaseTaxAmount - baseCredit - taxCredit, 0);
     const abatement = getProvincialAbatement(provincialCode, federalTax);
     return Math.max(federalTax - abatement, 0);
 }
@@ -552,10 +553,11 @@ export function getProvincialTaxAmount(
     grossIncome: number,
     inflationRate = 0,
     yearsToInflate = 0,
+    taxCredit = 0,
 ): number {
     const baseTaxAmount = getProvincialBaseTaxAmount(province, grossIncome, inflationRate, yearsToInflate);
     const baseCredit = getProvincialBaseCredit(province, inflationRate, yearsToInflate);
-    const tax = Math.max(baseTaxAmount - baseCredit, 0);
+    const tax = Math.max(baseTaxAmount - baseCredit - taxCredit, 0);
     const surTax = getProvincialSurtaxAmount(province, tax, inflationRate, yearsToInflate);
     return tax + surTax;
 }

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -1,0 +1,63 @@
+import {
+    getFederalBaseCredit, getFederalBaseTaxAmount,
+    getFederalTaxAmount, getProvincialAbatement,
+    getProvincialBaseCredit,
+    getProvincialBaseTaxAmount,
+    getProvincialSurtaxAmount,
+    getProvincialTaxAmount,
+} from '../income-tax';
+
+describe('getTaxAMount', () => {
+    describe('getProvincialTaxAmount', () => {
+        it('should calculate operations in the right order', () => {
+            const province = 'QC';
+            const grossIncome = 100000;
+            const inflationRate = 2.1;
+            const yearsToInflate = 0;
+            const taxCredit = 1000;
+            const baseTaxAmount = getProvincialBaseTaxAmount(
+                province,
+                grossIncome,
+                inflationRate,
+                yearsToInflate,
+            );
+            const baseCredit = getProvincialBaseCredit(province, inflationRate, yearsToInflate);
+            const tax = Math.max(baseTaxAmount - baseCredit - taxCredit, 0);
+            const surTax = getProvincialSurtaxAmount(province, tax, inflationRate, yearsToInflate);
+
+            const provincialTaxAmount = getProvincialTaxAmount(
+                province,
+                grossIncome,
+                inflationRate,
+                yearsToInflate,
+                taxCredit,
+            );
+
+            expect(provincialTaxAmount).toBe(tax + surTax);
+        });
+    });
+
+    describe('getFederalTaxAmount', () => {
+        it('should calculate operations in the right order', () => {
+            const province = 'QC';
+            const grossIncome = 100000;
+            const inflationRate = 2.1;
+            const yearsToInflate = 0;
+            const taxCredit = 1000;
+            const federalBaseTaxAmount = getFederalBaseTaxAmount(grossIncome, inflationRate, yearsToInflate);
+            const baseCredit = getFederalBaseCredit(inflationRate, yearsToInflate);
+            const federalTax = Math.max(federalBaseTaxAmount - baseCredit - taxCredit, 0);
+            const abatement = getProvincialAbatement(province, federalTax);
+
+            const federalTaxAmount = getFederalTaxAmount(
+                province,
+                grossIncome,
+                inflationRate,
+                yearsToInflate,
+                taxCredit,
+            );
+
+            expect(federalTaxAmount).toBe(federalTax - abatement);
+        });
+    });
+});


### PR DESCRIPTION
Description
 Ajout paramètre taxCredit au fonction de calcul de taxes provincial et fédéral

Note: J'voulais utiliser des mocks pour mes tests unitaires, mais y'aurait fallu du refactor et que je déplace des fonctions...

### Code quality
- [x] New features are unit tested.
