### PR TITLE
[ABF-9998] fix(ProvincialTax): Fix calcul impôt provincial

### DIFF
--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -557,9 +557,9 @@ export function getProvincialTaxAmount(
 ): number {
     const baseTaxAmount = getProvincialBaseTaxAmount(province, grossIncome, inflationRate, yearsToInflate);
     const baseCredit = getProvincialBaseCredit(province, inflationRate, yearsToInflate);
-    const tax = Math.max(baseTaxAmount - baseCredit - taxCredit, 0);
+    const tax = Math.max(baseTaxAmount - baseCredit, 0);
     const surTax = getProvincialSurtaxAmount(province, tax, inflationRate, yearsToInflate);
-    return tax + surTax;
+    return Math.max(tax + surTax - taxCredit, 0);
 }
 
 export function getFederalMarginalRate(

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -10,11 +10,11 @@ import {
 describe('getTaxAMount', () => {
     describe('getProvincialTaxAmount', () => {
         it('should calculate operations in the right order', () => {
-            const province = 'QC';
-            const grossIncome = 100000;
-            const inflationRate = 2.1;
+            const province = 'ON';
+            const grossIncome = 207000;
+            const inflationRate = 0.021;
             const yearsToInflate = 0;
-            const taxCredit = 1000;
+            const taxCredit = 20700;
             const baseTaxAmount = getProvincialBaseTaxAmount(
                 province,
                 grossIncome,
@@ -22,8 +22,9 @@ describe('getTaxAMount', () => {
                 yearsToInflate,
             );
             const baseCredit = getProvincialBaseCredit(province, inflationRate, yearsToInflate);
-            const tax = Math.max(baseTaxAmount - baseCredit - taxCredit, 0);
+            const tax = Math.max(baseTaxAmount - baseCredit, 0);
             const surTax = getProvincialSurtaxAmount(province, tax, inflationRate, yearsToInflate);
+            const expectedTax = Math.max(tax + surTax - taxCredit, 0);
 
             const provincialTaxAmount = getProvincialTaxAmount(
                 province,
@@ -33,7 +34,7 @@ describe('getTaxAMount', () => {
                 taxCredit,
             );
 
-            expect(provincialTaxAmount).toBe(tax + surTax);
+            expect(provincialTaxAmount).toBe(expectedTax);
         });
     });
 

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -9,12 +9,40 @@ import {
 
 describe('getTaxAMount', () => {
     describe('getProvincialTaxAmount', () => {
-        it('should calculate operations in the right order', () => {
+        it('should calculate operations in the right order for ON', () => {
             const province = 'ON';
             const grossIncome = 207000;
             const inflationRate = 0.021;
             const yearsToInflate = 0;
             const taxCredit = 20700;
+            const baseTaxAmount = getProvincialBaseTaxAmount(
+                province,
+                grossIncome,
+                inflationRate,
+                yearsToInflate,
+            );
+            const baseCredit = getProvincialBaseCredit(province, inflationRate, yearsToInflate);
+            const tax = Math.max(baseTaxAmount - baseCredit, 0);
+            const surTax = getProvincialSurtaxAmount(province, tax, inflationRate, yearsToInflate);
+            const expectedTax = Math.max(tax + surTax - taxCredit, 0);
+
+            const provincialTaxAmount = getProvincialTaxAmount(
+                province,
+                grossIncome,
+                inflationRate,
+                yearsToInflate,
+                taxCredit,
+            );
+
+            expect(provincialTaxAmount).toBe(expectedTax);
+        });
+
+        it('should calculate operations in the right order for QC', () => {
+            const province = 'QC';
+            const grossIncome = 209000;
+            const inflationRate = 0.021;
+            const yearsToInflate = 0;
+            const taxCredit = 20900;
             const baseTaxAmount = getProvincialBaseTaxAmount(
                 province,
                 grossIncome,


### PR DESCRIPTION
Description
Fix calcul impôt provincial

Dans le calcul d'impôts provincial, on calcul maintenant la surtax sur l'impôt avant la déduction du tax credit
