### PR TITLE
ABF-10324 feat(income-tax): Update federal lowest bracket tax rate from 0.15 to 0.145 for 2025, and to 0.14 for following years

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/jest": "30.0.0",
-    "@types/lodash": "4.17.19",
+    "@types/lodash.clonedeep": "4.5.9",
     "@types/node": "22.15.32",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
@@ -67,6 +67,6 @@
   },
   "packageManager": "yarn@4.9.2",
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash.clonedeep": "4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/jest": "30.0.0",
+    "@types/lodash": "4.17.19",
     "@types/node": "22.15.32",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
@@ -64,5 +65,8 @@
     "@babel/core/json5": "^2.2.2",
     "ts-jest/json5": "^2.2.2"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.9.2",
+  "dependencies": {
+    "lodash": "4.17.21"
+  }
 }

--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -6,8 +6,7 @@ Sources
 Revised
     2024-12-24
 */
-
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash.clonedeep';
 
 import { FEDERAL_CODE, FederalCode, ProvinceCode } from '../misc';
 import { maxBy, now, roundToPrecision } from '../utils';

--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -7,6 +7,8 @@ Revised
     2024-12-24
 */
 
+import cloneDeep from 'lodash/cloneDeep';
+
 import { FEDERAL_CODE, FederalCode, ProvinceCode } from '../misc';
 import { maxBy, now, roundToPrecision } from '../utils';
 
@@ -488,7 +490,7 @@ export function getRate(brackets: Rate[], grossIncome: number, inflationRate: nu
 }
 
 export function getTaxRates(code: ProvinceCode | FederalCode): Rate[] {
-    return TAX_BRACKETS[code].RATES;
+    return cloneDeep(TAX_BRACKETS[code].RATES);
 }
 
 function getAbatement(code: ProvinceCode | FederalCode): number {
@@ -496,17 +498,16 @@ function getAbatement(code: ProvinceCode | FederalCode): number {
 }
 
 function getSurtaxRates(code: ProvinceCode | FederalCode): Rate[] {
-    return TAX_BRACKETS[code].SURTAX_RATES;
+    return cloneDeep(TAX_BRACKETS[code].SURTAX_RATES);
 }
 
 export function getFederalTaxRates(yearsToInflate: number): Rate[] {
+    const rates = getTaxRates(FEDERAL_CODE);
     const shouldUse2025Rate = yearsToInflate === 0 && now().getFullYear() === 2025;
     if (shouldUse2025Rate) {
-        return getTaxRates(FEDERAL_CODE).map(
-            (rate, index) => ({ ...rate, RATE: index === 0 ? CA_LOWEST_TAX_RATE_2025 : rate.RATE }),
-        );
+        rates[0].RATE = CA_LOWEST_TAX_RATE_2025;
     }
-    return getTaxRates(FEDERAL_CODE);
+    return rates;
 }
 
 export function getFederalBaseTaxAmount(grossIncome: number, inflationRate = 0, yearsToInflate = 0): number {

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -5,7 +5,11 @@ import {
     getProvincialBaseTaxAmount,
     getProvincialSurtaxAmount,
     getProvincialTaxAmount,
+    getFederalTaxCreditRate,
+    getFederalTaxRates,
 } from '../income-tax';
+
+import * as Date from '../../utils/date';
 
 describe('getTaxAMount', () => {
     describe('getProvincialTaxAmount', () => {
@@ -87,6 +91,78 @@ describe('getTaxAMount', () => {
             );
 
             expect(federalTaxAmount).toBe(federalTax - abatement);
+        });
+    });
+
+    describe('getFederalTaxCreditRate', () => {
+        beforeEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('should return special tax credit rate when now is 2025', () => {
+            const yearsToInflate = 0;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2025, 0, 1));
+
+            const result = getFederalTaxCreditRate(yearsToInflate);
+
+            expect(result).toBe(0.145);
+        });
+
+        it('should return special tax credit rate when now is 2025 but inflating', () => {
+            const yearsToInflate = 1;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2025, 0, 1));
+
+            const result = getFederalTaxCreditRate(yearsToInflate);
+
+            expect(result).toBe(0.14);
+        });
+
+        it('should return regular tax credit rate when now is after 2025', () => {
+            const yearsToInflate = 0;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2026, 0, 1));
+
+            const result = getFederalTaxCreditRate(yearsToInflate);
+
+            expect(result).toBe(0.14);
+        });
+    });
+
+    describe('getFederalTaxRates', () => {
+        beforeEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('should return the correct rate for the first bracket when now is 2025', () => {
+            const yearsToInflate = 0;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2025, 0, 1));
+
+            const result = getFederalTaxRates(yearsToInflate);
+
+            expect(result[0].RATE).toBe(0.145);
+        });
+
+        it('should return the correct rate for the first bracket when now is 2025 but inflating', () => {
+            const yearsToInflate = 1;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2025, 0, 1));
+
+            const result = getFederalTaxRates(yearsToInflate);
+
+            expect(result[0].RATE).toBe(0.14);
+        });
+
+        it('should return the correct rate for the first bracket when now is after 2025', () => {
+            const yearsToInflate = 0;
+
+            jest.spyOn(Date, 'now').mockImplementation(() => new global.Date(2026, 0, 1));
+
+            const result = getFederalTaxRates(yearsToInflate);
+
+            expect(result[0].RATE).toBe(0.14);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,6 +1396,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
     "@types/jest": "npm:30.0.0"
+    "@types/lodash": "npm:4.17.19"
     "@types/node": "npm:22.15.32"
     "@typescript-eslint/eslint-plugin": "npm:7.18.0"
     "@typescript-eslint/parser": "npm:7.18.0"
@@ -1407,6 +1408,7 @@ __metadata:
     jest: "npm:30.0.2"
     jest-junit: "npm:16.0.0"
     jest-util: "npm:30.0.2"
+    lodash: "npm:4.17.21"
     ts-jest: "npm:29.4.0"
     typescript: "npm:5.8.3"
     yargs: "npm:18.0.0"
@@ -2068,6 +2070,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:4.17.19":
+  version: 4.17.19
+  resolution: "@types/lodash@npm:4.17.19"
+  checksum: 10c0/0d512e90a92c09b48ec0e46945876392d3ef60c0be7d023fdab22ecb0224a65ff4ed0b76c7acbf1c0152c27768aa4661ea7a1c3afb5b5ab13a50bda674a7c3f7
   languageName: node
   linkType: hard
 
@@ -5228,7 +5237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14":
+"lodash@npm:4.17.21, lodash@npm:^4.17.14":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,7 +1396,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
     "@types/jest": "npm:30.0.0"
-    "@types/lodash": "npm:4.17.19"
+    "@types/lodash.clonedeep": "npm:4.5.9"
     "@types/node": "npm:22.15.32"
     "@typescript-eslint/eslint-plugin": "npm:7.18.0"
     "@typescript-eslint/parser": "npm:7.18.0"
@@ -1408,7 +1408,7 @@ __metadata:
     jest: "npm:30.0.2"
     jest-junit: "npm:16.0.0"
     jest-util: "npm:30.0.2"
-    lodash: "npm:4.17.21"
+    lodash.clonedeep: "npm:4.5.0"
     ts-jest: "npm:29.4.0"
     typescript: "npm:5.8.3"
     yargs: "npm:18.0.0"
@@ -2073,7 +2073,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:4.17.19":
+"@types/lodash.clonedeep@npm:4.5.9":
+  version: 4.5.9
+  resolution: "@types/lodash.clonedeep@npm:4.5.9"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10c0/2f224ce9578046bccd1cd9594fb73540600ebd3d59a45695166a6123e2c376b84ab106b005a00453f357907f25bc8bfd2271b822be76e8f5527eadb4690b5e96
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
   version: 4.17.19
   resolution: "@types/lodash@npm:4.17.19"
   checksum: 10c0/0d512e90a92c09b48ec0e46945876392d3ef60c0be7d023fdab22ecb0224a65ff4ed0b76c7acbf1c0152c27768aa4661ea7a1c3afb5b5ab13a50bda674a7c3f7
@@ -5216,6 +5225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.clonedeep@npm:4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 10c0/2caf0e4808f319d761d2939ee0642fa6867a4bbf2cfce43276698828380756b99d4c4fa226d881655e6ac298dd453fe12a5ec8ba49861777759494c534936985
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -5237,7 +5253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.14":
+"lodash@npm:^4.17.14":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c


### PR DESCRIPTION
ABF-10324

### Specific tests
- [ ] Le taux d'imposition et du crédit de base au fédéral passe à 0.145 pour 2025
- [ ] Le taux d'imposition et du crédit de base au fédéral passe à 0.14 pour 2026 et plus
- [ ] BONUS: Même si on oublie d'effacer ce code en janvier 2026, les calculs vont rester bons 🎉 


### Code quality
- [ ] New features are unit tested.
