### PR TITLE
DOPS-6017 ci: Change NPM token by NPM OICD

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -106,6 +106,9 @@ jobs:
     name: Publish to npm
     environment: npm-deployment
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - setup
       - jest
@@ -135,12 +138,6 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           contents="$(jq ".version = \"${VERSION}\"" ./package.json)" && echo "${contents}" > ./package.json
-
-      - name: NPM Login
-        uses: equisoft-actions/yarn-npm-login@v1
-        with:
-          registry: registry.yarnpkg.com
-          token: ${{ secrets.NPM_TOKEN }}
 
       - name: Yarn publish
         env:


### PR DESCRIPTION
Configuré dans NPM.
Pour que ça fonctionne, il suffit d'ajouter la permission id-token et de retirer le npm login, ça va utiliser du OICD pour publier à la place du token.

<img width="798" height="248" alt="image" src="https://github.com/user-attachments/assets/40732b02-6209-4da1-adf5-b0d509c7aa72" />
