### PR TITLE
ABF-12779: Appliquer la réduction progressive du BPA bonifié au calcul d'impôt fédéral

### DIFF
--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -19,8 +19,7 @@ export interface Rate {
 export interface TaxBracket {
     ABATEMENT: number;
     TAX_CREDIT_RATE: number;
-    BASE_PERSONAL_AMOUNT_MAX: number;
-    BASE_PERSONAL_AMOUNT_MIN?: number;
+    BASIC_PERSONAL_AMOUNT: number | { MIN: number; MAX: number };
     RATES: Rate[];
     SURTAX_RATES: Rate[];
 }
@@ -31,8 +30,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     CA: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.14,
-        BASE_PERSONAL_AMOUNT_MAX: 16452,
-        BASE_PERSONAL_AMOUNT_MIN: 14829,
+        BASIC_PERSONAL_AMOUNT: { MIN: 14829, MAX: 16452 },
         RATES: [{
             FROM: 0,
             TO: 58523,
@@ -63,7 +61,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     AB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.08,
-        BASE_PERSONAL_AMOUNT_MAX: 22769,
+        BASIC_PERSONAL_AMOUNT: 22769,
         RATES: [{
             FROM: 0,
             TO: 61200,
@@ -98,7 +96,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     BC: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0506,
-        BASE_PERSONAL_AMOUNT_MAX: 13216,
+        BASIC_PERSONAL_AMOUNT: 13216,
         RATES: [{
             FROM: 0,
             TO: 50363,
@@ -137,7 +135,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     MB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.108,
-        BASE_PERSONAL_AMOUNT_MAX: 15780,
+        BASIC_PERSONAL_AMOUNT: 15780,
         RATES: [{
             FROM: 0,
             TO: 47000,
@@ -160,7 +158,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.094,
-        BASE_PERSONAL_AMOUNT_MAX: 13664,
+        BASIC_PERSONAL_AMOUNT: 13664,
         RATES: [{
             FROM: 0,
             TO: 52333,
@@ -187,7 +185,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NL: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.087,
-        BASE_PERSONAL_AMOUNT_MAX: 11188,
+        BASIC_PERSONAL_AMOUNT: 11188,
         RATES: [{
             FROM: 0,
             TO: 44678,
@@ -230,7 +228,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NS: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0879,
-        BASE_PERSONAL_AMOUNT_MAX: 11932,
+        BASIC_PERSONAL_AMOUNT: 11932,
         RATES: [{
             FROM: 0,
             TO: 30995,
@@ -261,7 +259,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     PE: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.095,
-        BASE_PERSONAL_AMOUNT_MAX: 15000,
+        BASIC_PERSONAL_AMOUNT: 15000,
         RATES: [{
             FROM: 0,
             TO: 33928,
@@ -292,7 +290,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     ON: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0505,
-        BASE_PERSONAL_AMOUNT_MAX: 12989,
+        BASIC_PERSONAL_AMOUNT: 12989,
         RATES: [{
             FROM: 0,
             TO: 53891,
@@ -331,7 +329,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     QC: {
         ABATEMENT: 0.165,
         TAX_CREDIT_RATE: 0.14,
-        BASE_PERSONAL_AMOUNT_MAX: 18952,
+        BASIC_PERSONAL_AMOUNT: 18952,
         RATES: [{
             FROM: 0,
             TO: 54345,
@@ -358,7 +356,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     SK: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.105,
-        BASE_PERSONAL_AMOUNT_MAX: 20381,
+        BASIC_PERSONAL_AMOUNT: 20381,
         RATES: [{
             FROM: 0,
             TO: 54532,
@@ -381,7 +379,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NT: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.059,
-        BASE_PERSONAL_AMOUNT_MAX: 18198,
+        BASIC_PERSONAL_AMOUNT: 18198,
         RATES: [{
             FROM: 0,
             TO: 53003,
@@ -408,7 +406,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NU: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.04,
-        BASE_PERSONAL_AMOUNT_MAX: 19659,
+        BASIC_PERSONAL_AMOUNT: 19659,
         RATES: [{
             FROM: 0,
             TO: 55801,
@@ -435,7 +433,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     YT: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.14,
-        BASE_PERSONAL_AMOUNT_MAX: 16452,
+        BASIC_PERSONAL_AMOUNT: 16452,
         RATES: [{
             FROM: 0,
             TO: 58523,
@@ -511,17 +509,18 @@ export function getFederalTaxCreditRate(): number {
     return TAX_BRACKETS.CA.TAX_CREDIT_RATE;
 }
 
-export function getFederalBasePersonalAmount(
+export function getFederalBasicPersonalAmount(
     grossIncome: number,
     inflationRate: number,
     yearsToInflate: number,
 ): number {
-    const maxBPA = TAX_BRACKETS.CA.BASE_PERSONAL_AMOUNT_MAX;
-    const minBPA = TAX_BRACKETS.CA.BASE_PERSONAL_AMOUNT_MIN ?? maxBPA;
+    const bpaConfig = TAX_BRACKETS.CA.BASIC_PERSONAL_AMOUNT;
+    const maxBPA = typeof bpaConfig === 'number' ? bpaConfig : bpaConfig.MAX;
+    const minBPA = typeof bpaConfig === 'number' ? bpaConfig : bpaConfig.MIN;
     const bonus = maxBPA - minBPA;
     const rates = TAX_BRACKETS.CA.RATES;
-    const lowerThreshold = inflate(rates[3].FROM, inflationRate, yearsToInflate);
-    const upperThreshold = inflate(rates[3].TO, inflationRate, yearsToInflate);
+    const lowerThreshold = inflate(rates[rates.length - 1].FROM, inflationRate, yearsToInflate);
+    const upperThreshold = inflate(rates[rates.length - 1].TO, inflationRate, yearsToInflate);
 
     if (grossIncome <= lowerThreshold) {
         return maxBPA;
@@ -534,7 +533,7 @@ export function getFederalBasePersonalAmount(
 }
 
 export function getFederalBaseCredit(grossIncome: number, inflationRate: number, yearsToInflate: number): number {
-    const bpa = getFederalBasePersonalAmount(grossIncome, inflationRate, yearsToInflate);
+    const bpa = getFederalBasicPersonalAmount(grossIncome, inflationRate, yearsToInflate);
     const baseTaxCredit = bpa * getFederalTaxCreditRate();
     return inflate(baseTaxCredit, inflationRate, yearsToInflate);
 }
@@ -576,7 +575,9 @@ export function getProvincialBaseTaxAmount(
 }
 
 export function getProvincialBaseCredit(province: ProvinceCode, inflationRate: number, yearsToInflate: number): number {
-    const baseTaxCredit = TAX_BRACKETS[province].BASE_PERSONAL_AMOUNT_MAX * TAX_BRACKETS[province].RATES[0].RATE;
+    const bpaConfig = TAX_BRACKETS[province].BASIC_PERSONAL_AMOUNT;
+    const bpa = typeof bpaConfig === 'number' ? bpaConfig : bpaConfig.MAX;
+    const baseTaxCredit = bpa * TAX_BRACKETS[province].RATES[0].RATE;
     return inflate(baseTaxCredit, inflationRate, yearsToInflate);
 }
 

--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -519,8 +519,8 @@ export function getFederalBasicPersonalAmount(
     const minBPA = typeof bpaConfig === 'number' ? bpaConfig : bpaConfig.MIN;
     const bonus = maxBPA - minBPA;
     const rates = TAX_BRACKETS.CA.RATES;
-    const lowerThreshold = inflate(rates[rates.length - 1].FROM, inflationRate, yearsToInflate);
-    const upperThreshold = inflate(rates[rates.length - 1].TO, inflationRate, yearsToInflate);
+    const lowerThreshold = inflate(rates[rates.length - 2].FROM, inflationRate, yearsToInflate);
+    const upperThreshold = inflate(rates[rates.length - 2].TO, inflationRate, yearsToInflate);
 
     if (grossIncome <= lowerThreshold) {
         return maxBPA;

--- a/src/taxes/income-tax.ts
+++ b/src/taxes/income-tax.ts
@@ -19,7 +19,8 @@ export interface Rate {
 export interface TaxBracket {
     ABATEMENT: number;
     TAX_CREDIT_RATE: number;
-    BASE_TAX_CREDIT: number;
+    BASE_PERSONAL_AMOUNT_MAX: number;
+    BASE_PERSONAL_AMOUNT_MIN?: number;
     RATES: Rate[];
     SURTAX_RATES: Rate[];
 }
@@ -30,7 +31,8 @@ export const TAX_BRACKETS: TaxBrackets = {
     CA: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.14,
-        BASE_TAX_CREDIT: 16452,
+        BASE_PERSONAL_AMOUNT_MAX: 16452,
+        BASE_PERSONAL_AMOUNT_MIN: 14829,
         RATES: [{
             FROM: 0,
             TO: 58523,
@@ -61,7 +63,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     AB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.08,
-        BASE_TAX_CREDIT: 22769,
+        BASE_PERSONAL_AMOUNT_MAX: 22769,
         RATES: [{
             FROM: 0,
             TO: 61200,
@@ -96,7 +98,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     BC: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0506,
-        BASE_TAX_CREDIT: 13216,
+        BASE_PERSONAL_AMOUNT_MAX: 13216,
         RATES: [{
             FROM: 0,
             TO: 50363,
@@ -135,7 +137,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     MB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.108,
-        BASE_TAX_CREDIT: 15780,
+        BASE_PERSONAL_AMOUNT_MAX: 15780,
         RATES: [{
             FROM: 0,
             TO: 47000,
@@ -158,7 +160,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NB: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.094,
-        BASE_TAX_CREDIT: 13664,
+        BASE_PERSONAL_AMOUNT_MAX: 13664,
         RATES: [{
             FROM: 0,
             TO: 52333,
@@ -185,7 +187,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NL: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.087,
-        BASE_TAX_CREDIT: 11188,
+        BASE_PERSONAL_AMOUNT_MAX: 11188,
         RATES: [{
             FROM: 0,
             TO: 44678,
@@ -228,7 +230,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NS: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0879,
-        BASE_TAX_CREDIT: 11932,
+        BASE_PERSONAL_AMOUNT_MAX: 11932,
         RATES: [{
             FROM: 0,
             TO: 30995,
@@ -259,7 +261,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     PE: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.095,
-        BASE_TAX_CREDIT: 15000,
+        BASE_PERSONAL_AMOUNT_MAX: 15000,
         RATES: [{
             FROM: 0,
             TO: 33928,
@@ -290,7 +292,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     ON: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.0505,
-        BASE_TAX_CREDIT: 12989,
+        BASE_PERSONAL_AMOUNT_MAX: 12989,
         RATES: [{
             FROM: 0,
             TO: 53891,
@@ -329,7 +331,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     QC: {
         ABATEMENT: 0.165,
         TAX_CREDIT_RATE: 0.14,
-        BASE_TAX_CREDIT: 18952,
+        BASE_PERSONAL_AMOUNT_MAX: 18952,
         RATES: [{
             FROM: 0,
             TO: 54345,
@@ -356,7 +358,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     SK: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.105,
-        BASE_TAX_CREDIT: 20381,
+        BASE_PERSONAL_AMOUNT_MAX: 20381,
         RATES: [{
             FROM: 0,
             TO: 54532,
@@ -379,7 +381,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NT: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.059,
-        BASE_TAX_CREDIT: 18198,
+        BASE_PERSONAL_AMOUNT_MAX: 18198,
         RATES: [{
             FROM: 0,
             TO: 53003,
@@ -406,7 +408,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     NU: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.04,
-        BASE_TAX_CREDIT: 19659,
+        BASE_PERSONAL_AMOUNT_MAX: 19659,
         RATES: [{
             FROM: 0,
             TO: 55801,
@@ -433,7 +435,7 @@ export const TAX_BRACKETS: TaxBrackets = {
     YT: {
         ABATEMENT: 0,
         TAX_CREDIT_RATE: 0.14,
-        BASE_TAX_CREDIT: 16452,
+        BASE_PERSONAL_AMOUNT_MAX: 16452,
         RATES: [{
             FROM: 0,
             TO: 58523,
@@ -509,8 +511,31 @@ export function getFederalTaxCreditRate(): number {
     return TAX_BRACKETS.CA.TAX_CREDIT_RATE;
 }
 
-export function getFederalBaseCredit(inflationRate: number, yearsToInflate: number): number {
-    const baseTaxCredit = TAX_BRACKETS.CA.BASE_TAX_CREDIT * getFederalTaxCreditRate();
+export function getFederalBasePersonalAmount(
+    grossIncome: number,
+    inflationRate: number,
+    yearsToInflate: number,
+): number {
+    const maxBPA = TAX_BRACKETS.CA.BASE_PERSONAL_AMOUNT_MAX;
+    const minBPA = TAX_BRACKETS.CA.BASE_PERSONAL_AMOUNT_MIN ?? maxBPA;
+    const bonus = maxBPA - minBPA;
+    const rates = TAX_BRACKETS.CA.RATES;
+    const lowerThreshold = inflate(rates[3].FROM, inflationRate, yearsToInflate);
+    const upperThreshold = inflate(rates[3].TO, inflationRate, yearsToInflate);
+
+    if (grossIncome <= lowerThreshold) {
+        return maxBPA;
+    }
+    if (grossIncome >= upperThreshold) {
+        return minBPA;
+    }
+    const reduction = bonus * (grossIncome - lowerThreshold) / (upperThreshold - lowerThreshold);
+    return maxBPA - reduction;
+}
+
+export function getFederalBaseCredit(grossIncome: number, inflationRate: number, yearsToInflate: number): number {
+    const bpa = getFederalBasePersonalAmount(grossIncome, inflationRate, yearsToInflate);
+    const baseTaxCredit = bpa * getFederalTaxCreditRate();
     return inflate(baseTaxCredit, inflationRate, yearsToInflate);
 }
 
@@ -526,7 +551,7 @@ export function getFederalTaxAmount(
     taxCredit = 0,
 ): number {
     const federalBaseTaxAmount = getFederalBaseTaxAmount(grossIncome, inflationRate, yearsToInflate);
-    const baseCredit = getFederalBaseCredit(inflationRate, yearsToInflate);
+    const baseCredit = getFederalBaseCredit(grossIncome, inflationRate, yearsToInflate);
     const federalTax = Math.max(federalBaseTaxAmount - baseCredit - taxCredit, 0);
     const abatement = getProvincialAbatement(provincialCode, federalTax);
     return Math.max(federalTax - abatement, 0);
@@ -551,7 +576,7 @@ export function getProvincialBaseTaxAmount(
 }
 
 export function getProvincialBaseCredit(province: ProvinceCode, inflationRate: number, yearsToInflate: number): number {
-    const baseTaxCredit = TAX_BRACKETS[province].BASE_TAX_CREDIT * TAX_BRACKETS[province].RATES[0].RATE;
+    const baseTaxCredit = TAX_BRACKETS[province].BASE_PERSONAL_AMOUNT_MAX * TAX_BRACKETS[province].RATES[0].RATE;
     return inflate(baseTaxCredit, inflationRate, yearsToInflate);
 }
 

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -1,6 +1,6 @@
 import {
     getFederalBaseCredit, getFederalBaseTaxAmount,
-    getFederalBasePersonalAmount,
+    getFederalBasicPersonalAmount,
     getFederalTaxAmount,
     getProvincialAbatement,
     getProvincialBaseCredit,
@@ -105,7 +105,7 @@ describe('getTaxAMount', () => {
         ])(
             'should return BPA=$expectedBPA for income $grossIncome',
             ({ grossIncome, expectedBPA }) => {
-                const bpa = getFederalBasePersonalAmount(grossIncome, 0, 0);
+                const bpa = getFederalBasicPersonalAmount(grossIncome, 0, 0);
                 expect(roundToPrecision(bpa, 2)).toBe(expectedBPA);
             },
         );

--- a/src/taxes/tests/income-tax.spec.ts
+++ b/src/taxes/tests/income-tax.spec.ts
@@ -1,11 +1,14 @@
 import {
     getFederalBaseCredit, getFederalBaseTaxAmount,
-    getFederalTaxAmount, getProvincialAbatement,
+    getFederalBasePersonalAmount,
+    getFederalTaxAmount,
+    getProvincialAbatement,
     getProvincialBaseCredit,
     getProvincialBaseTaxAmount,
     getProvincialSurtaxAmount,
     getProvincialTaxAmount,
 } from '../income-tax';
+import { roundToPrecision } from '../../utils';
 
 describe('getTaxAMount', () => {
     describe('getProvincialTaxAmount', () => {
@@ -74,7 +77,7 @@ describe('getTaxAMount', () => {
             const yearsToInflate = 0;
             const taxCredit = 1000;
             const federalBaseTaxAmount = getFederalBaseTaxAmount(grossIncome, inflationRate, yearsToInflate);
-            const baseCredit = getFederalBaseCredit(inflationRate, yearsToInflate);
+            const baseCredit = getFederalBaseCredit(grossIncome, inflationRate, yearsToInflate);
             const federalTax = Math.max(federalBaseTaxAmount - baseCredit - taxCredit, 0);
             const abatement = getProvincialAbatement(province, federalTax);
 
@@ -88,5 +91,41 @@ describe('getTaxAMount', () => {
 
             expect(federalTaxAmount).toBe(federalTax - abatement);
         });
+    });
+
+    describe('getFederalBasePersonalAmount', () => {
+        it.each([
+            { grossIncome: 60000, expectedBPA: 16452.00 },
+            { grossIncome: 150000, expectedBPA: 16452.00 },
+            { grossIncome: 181440, expectedBPA: 16452.00 },
+            { grossIncome: 210000, expectedBPA: 15850.34 },
+            { grossIncome: 221435, expectedBPA: 15609.45 },
+            { grossIncome: 258482, expectedBPA: 14829.00 },
+            { grossIncome: 300000, expectedBPA: 14829.00 },
+        ])(
+            'should return BPA=$expectedBPA for income $grossIncome',
+            ({ grossIncome, expectedBPA }) => {
+                const bpa = getFederalBasePersonalAmount(grossIncome, 0, 0);
+                expect(roundToPrecision(bpa, 2)).toBe(expectedBPA);
+            },
+        );
+    });
+
+    describe('getFederalBaseCredit', () => {
+        it.each([
+            { grossIncome: 60000, expectedCredit: 2303.28 },
+            { grossIncome: 150000, expectedCredit: 2303.28 },
+            { grossIncome: 181440, expectedCredit: 2303.28 },
+            { grossIncome: 210000, expectedCredit: 2219.05 },
+            { grossIncome: 221435, expectedCredit: 2185.32 },
+            { grossIncome: 258482, expectedCredit: 2076.06 },
+            { grossIncome: 300000, expectedCredit: 2076.06 },
+        ])(
+            'should return credit=$expectedCredit for income $grossIncome',
+            ({ grossIncome, expectedCredit }) => {
+                const credit = getFederalBaseCredit(grossIncome, 0, 0);
+                expect(roundToPrecision(credit, 2)).toBe(expectedCredit);
+            },
+        );
     });
 });


### PR DESCRIPTION
Description
Appliquer la réduction progressive du BPA bonifié au calcul d'impôt fédéral

**À confirmer:**
J'ai modifié BASE_TAX_CREDIT -> BASE_PERSONAL_AMOUNT_MAX.

Fna-engine l'utilise donc j'vais devoir modifier quand je bump. Breaking change, est-ce que je serais mieux de garder la constante vu que c'est une lib publique et on peut pas vraiment faire de majeur...?

### Code quality
- [x] New features are unit tested.
